### PR TITLE
Reproduction for issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@
 The `Request the page` step has a timeout of 1 minute, which never finishes.
 
 If you remove the `Run wrangler` step, fetching the `index.html` fails right away.
+


### PR DESCRIPTION
[.github/workflows/docker.yml](https://github.com/hamstercat/wrangler-docker-reproduction/blob/main/.github/workflows/docker.yml) uses the `node:22` docker image to install wrangler (through npm), serve the `/dist` folder, and then query the `index.html` file.

The `Request the page` step has a timeout of 1 minute, which never finishes.

If you remove the `Run wrangler` step, fetching the `index.html` fails right away.
